### PR TITLE
disable convenience symlinks in examples

### DIFF
--- a/example/dep-cc_test/.bazelrc
+++ b/example/dep-cc_test/.bazelrc
@@ -1,5 +1,8 @@
 common --enable_bzlmod=false
 
+# older Bazel versions may not support --experimental_convenience_symlinks
+build --symlink_prefix=/
+
 build:clang-tidy --aspects=@rules_clang_tidy//:aspects.bzl%check
 build:clang-tidy --output_groups=report
 

--- a/example/hermetic-toolchain/.bazelrc
+++ b/example/hermetic-toolchain/.bazelrc
@@ -1,5 +1,8 @@
 common --enable_bzlmod=false
 
+# older Bazel versions may not support --experimental_convenience_symlinks
+build --symlink_prefix=/
+
 build:clang-tidy --aspects=@rules_clang_tidy//:aspects.bzl%check
 build:clang-tidy --output_groups=report
 

--- a/example/misc-unused/.bazelrc
+++ b/example/misc-unused/.bazelrc
@@ -1,5 +1,8 @@
 common --enable_bzlmod=false
 
+# older Bazel versions may not support --experimental_convenience_symlinks
+build --symlink_prefix=/
+
 build:clang-tidy --aspects=@rules_clang_tidy//:aspects.bzl%check
 build:clang-tidy --output_groups=report
 

--- a/example/shared-source/.bazelrc
+++ b/example/shared-source/.bazelrc
@@ -1,5 +1,8 @@
 common --enable_bzlmod=false
 
+# older Bazel versions may not support --experimental_convenience_symlinks
+build --symlink_prefix=/
+
 build:clang-tidy --aspects=@rules_clang_tidy//:aspects.bzl%check
 build:clang-tidy --output_groups=report
 


### PR DESCRIPTION
Prevent convenience symlinks from being generated - they can cause
cycles that crash Bazel:

ERROR: Cycle detected but could not be properly displayed due to an internal problem. Please file an issue. Raw display: topLevelKey: BuildDriverKey of ActionLookupKey: ConfiguredTargetKey{label=//:apply-fixes.verify, config=BuildConfigurationKey[b357dd09923b37f48f631ab81341a90e6b4443fce0a2dddfde9d204ca537a54e]}
alreadyReported: false
path to cycle:
BuildDriverKey of ActionLookupKey: ConfiguredTargetKey{label=//:apply-fixes.verify, config=BuildConfigurationKey[b357dd09923b37f48f631ab81341a90e6b4443fce0a2dddfde9d204ca537a54e]}
ConfiguredTargetKey{label=//:apply-fixes.verify, config=BuildConfigurationKey[b357dd09923b37f48f631ab81341a90e6b4443fce0a2dddfde9d204ca537a54e]}
ConfiguredTargetKey{label=//:apply-fixes.verify, config=BuildConfigurationKey[5c864536bb2c4dd7b84e076a6dab8f700df816ad8f8998bb302a45cc805cb966]}
ConfiguredTargetKey{label=@@local_clang_tidy_workspace_status//:status, config=BuildConfigurationKey[5c864536bb2c4dd7b84e076a6dab8f700df816ad8f8998bb302a45cc805cb966]}
...

Change-Id: Ieb3098c28157313400d5be807ae47679800fbef8